### PR TITLE
Add check for existing slots, option to add to manifest

### DIFF
--- a/gst
+++ b/gst
@@ -12,9 +12,11 @@ import shutil
 
 import romsupport
 
+
 def print_err(message):
     """write a message to stderr"""
     print(message, file=sys.stderr)
+
 
 class Gst:
     """Manage SD cards"""
@@ -57,11 +59,6 @@ class Gst:
             src = game['src']
             name = game['name']
 
-            self.debug(f"testing if file exists: {src}")
-            if not os.path.isfile(src):
-                print_err(f"file does not exist: {src}")
-                sys.exit(1)
-
             self.slots.append(romsupport.Rom(src, name))
 
     def create_directories(self):
@@ -71,7 +68,24 @@ class Gst:
             # anything larger just uses its natural length. This fits that.
             slot_dir = f"{slot:02}"
             self.debug(f"Creating dir: {self.mnt}/{slot_dir}")
-            os.mkdir(f"{self.mnt}/{slot_dir}")
+            try:
+                os.mkdir(f"{self.mnt}/{slot_dir}")
+            except FileExistsError:
+                # Read the the 'name.txt' file in the existing directory and check if the name matches
+                # the name of the ROM we're trying to copy. If it does, skip the folder. If it doesn't,
+                # set skip to False so that the folder is deleted and recreated.
+                translated_slot = slot - 1
+                try:
+                    with open(f"{self.mnt}/{slot_dir}/name.txt") as name_file:
+                        name = name_file.readline().rstrip()
+                        if self.slots[translated_slot].name == name:
+                            self.slots[translated_slot].skip = True
+                        else:
+                            print_err(f"Slot {slot} already contains {name}, while the manifast has {self.slots[slot].name}")
+                            self.slots[translated_slot].skip = False
+                except FileNotFoundError:
+                    # If there's no 'name.txt' file, set skip to False so that the folder is deleted and recreated.
+                    self.slots[translated_slot].skip = False
 
     def copy_files(self):
         """Copy GDEMU ini and invoke appropriate copy routine from each slot"""
@@ -90,6 +104,22 @@ class Gst:
         """Place a copy of the manifest file onto the SD card"""
         shutil.copyfile(self.manifest, f"{self.mnt}/manifest.json")
 
+
+def add_game(manifest, name, src):
+    if name is None:
+        print_err("Name must be specified with -n")
+        sys.exit(1)
+    if os.path.isfile(src) is False:
+        print_err(f"{src} is not a file or does not exist")
+        sys.exit(1)
+    with open(manifest, 'r+') as json_file:
+        manifest = json.load(json_file)
+        manifest['slots'].append({'name': name, 'src': src})
+        json_file.seek(0)
+        json.dump(manifest, json_file, indent=4)
+        json_file.truncate()
+
+
 def main():
     """entrypoint for the program"""
 
@@ -98,17 +128,32 @@ def main():
         '-m', '--manifest', required=True,
         help='JSON manifest describing desired image layout')
     parser.add_argument(
-        '-t', '--target', required=True,
+        '-t', '--target', required=False,
         help='Filesystem target directory for mounted SD card')
     parser.add_argument(
         "-v", "--verbose", action='store_true', help="Enable verbose output")
+    parser.add_argument(
+        '-a', '--add', required=False,
+        help='File to be added to the manifest')
+    parser.add_argument(
+        '-n', '--name', required=False,
+        help='Name of the game to be added to the manifest'
+    )
     args = parser.parse_args()
 
-    gst = Gst(mnt=args.target, manifest=args.manifest, verbose=args.verbose)
-    gst.parse_manifest()
-    gst.copy_manifest()
-    gst.create_directories()
-    gst.copy_files()
+    if args.target is None and args.add is None:
+        print_err("Either -t or -a must be specified")
+        sys.exit(1)
+
+    if args.target is not None:
+        gst = Gst(mnt=args.target, manifest=args.manifest, verbose=args.verbose)
+        gst.parse_manifest()
+        gst.copy_manifest()
+        gst.create_directories()
+        gst.copy_files()
+    if args.add is not None:
+        add_game(args.manifest, args.name, args.add)
+
 
 if __name__ == "__main__":
     main()

--- a/romsupport/rom.py
+++ b/romsupport/rom.py
@@ -1,6 +1,7 @@
 """Dreamcast ROM Class"""
 
 import os.path
+from os import mkdir
 import shutil
 
 import romsupport
@@ -26,6 +27,12 @@ class Rom:
 
     def translate_rom(self, dst_dir):
         """Initiate copying and transforming ROM contents to destination."""
+        if hasattr(self, 'skip') and self.skip is True:
+            print(f"skipping rom {self.name}")
+            return
+        elif hasattr(self, 'skip') and self.skip is False:
+            shutil.rmtree(dst_dir)
+            mkdir(dst_dir)
         print(f"translating rom {self.name}")
         # get a list of all the files to copy and loop over them
         for filename in self.handler.get_filenames():


### PR DESCRIPTION
This commit adds a check if an existing slot in the destination has the correct game.
This enables the possibility to add games later on, without having to completely recopy everything.

It also adds a new cli argument "-a/--add" to add a zip file to the manifest.
Example:
```
./gst -m manifest.json -a "/mnt/DC/Game.zip" -n NameofGame
```

This makes it somewhat more comfortable to add games to the manifest, without having to manually edit it.